### PR TITLE
Move `Signal` operators to files

### DIFF
--- a/Fx.xcodeproj/project.pbxproj
+++ b/Fx.xcodeproj/project.pbxproj
@@ -88,6 +88,48 @@
 		5FD28AE11D5B2EE300BAFC0F /* Fx iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FD28AD31D5B2E6300BAFC0F /* Fx iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5FD28AE31D5B2EEA00BAFC0F /* Fx tvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FD28AD91D5B2E6300BAFC0F /* Fx tvOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5FDB3D8020EE6C4F0006CD8E /* FnFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDB3D7F20EE6C4F0006CD8E /* FnFunctions.swift */; };
+		87F13D8626C13D060069A488 /* Take.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D8526C13D060069A488 /* Take.swift */; };
+		87F13D8E26C13D180069A488 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D8D26C13D180069A488 /* Map.swift */; };
+		87F13D9926C13DB10069A488 /* AsVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D9826C13DB10069A488 /* AsVoid.swift */; };
+		87F13D9E26C13EBF0069A488 /* Observe+ExecutionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D9D26C13EBF0069A488 /* Observe+ExecutionContext.swift */; };
+		87F13DA826C14CDE0069A488 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D8D26C13D180069A488 /* Map.swift */; };
+		87F13DAC26C14CDE0069A488 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D8D26C13D180069A488 /* Map.swift */; };
+		87F13DB026C14CE10069A488 /* Take.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D8526C13D060069A488 /* Take.swift */; };
+		87F13DB426C14CE10069A488 /* Take.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D8526C13D060069A488 /* Take.swift */; };
+		87F13DB526C14CE30069A488 /* AsVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D9826C13DB10069A488 /* AsVoid.swift */; };
+		87F13DB926C14CE30069A488 /* AsVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D9826C13DB10069A488 /* AsVoid.swift */; };
+		87F13DBD26C14CE50069A488 /* Observe+ExecutionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D9D26C13EBF0069A488 /* Observe+ExecutionContext.swift */; };
+		87F13DC126C14CE60069A488 /* Observe+ExecutionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13D9D26C13EBF0069A488 /* Observe+ExecutionContext.swift */; };
+		87F13DC626C14D320069A488 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DC526C14D320069A488 /* Filter.swift */; };
+		87F13DCA26C14D340069A488 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DC526C14D320069A488 /* Filter.swift */; };
+		87F13DCE26C14D350069A488 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DC526C14D320069A488 /* Filter.swift */; };
+		87F13DD326C14D9D0069A488 /* Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DD226C14D9D0069A488 /* Merge.swift */; };
+		87F13DD426C14D9D0069A488 /* Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DD226C14D9D0069A488 /* Merge.swift */; };
+		87F13DD526C14D9D0069A488 /* Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DD226C14D9D0069A488 /* Merge.swift */; };
+		87F13DDA26C14EF00069A488 /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DD926C14EF00069A488 /* CombineLatest.swift */; };
+		87F13DDB26C14EF00069A488 /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DD926C14EF00069A488 /* CombineLatest.swift */; };
+		87F13DDC26C14EF00069A488 /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DD926C14EF00069A488 /* CombineLatest.swift */; };
+		87F13DE126C14F370069A488 /* Zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DE026C14F370069A488 /* Zip.swift */; };
+		87F13DE226C14F370069A488 /* Zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DE026C14F370069A488 /* Zip.swift */; };
+		87F13DE326C14F370069A488 /* Zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DE026C14F370069A488 /* Zip.swift */; };
+		87F13DE826C150530069A488 /* Throttled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DE726C150530069A488 /* Throttled.swift */; };
+		87F13DE926C150530069A488 /* Throttled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DE726C150530069A488 /* Throttled.swift */; };
+		87F13DEA26C150530069A488 /* Throttled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DE726C150530069A488 /* Throttled.swift */; };
+		87F13DEF26C150940069A488 /* IgnoringNils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DEE26C150940069A488 /* IgnoringNils.swift */; };
+		87F13DF026C150940069A488 /* IgnoringNils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DEE26C150940069A488 /* IgnoringNils.swift */; };
+		87F13DF126C150940069A488 /* IgnoringNils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DEE26C150940069A488 /* IgnoringNils.swift */; };
+		87F13DF626C1516B0069A488 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DF526C1516B0069A488 /* CompactMap.swift */; };
+		87F13DF726C1516B0069A488 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DF526C1516B0069A488 /* CompactMap.swift */; };
+		87F13DF826C1516B0069A488 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DF526C1516B0069A488 /* CompactMap.swift */; };
+		87F13DFD26C1521E0069A488 /* FlatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DFC26C1521E0069A488 /* FlatMap.swift */; };
+		87F13DFE26C1521E0069A488 /* FlatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DFC26C1521E0069A488 /* FlatMap.swift */; };
+		87F13DFF26C1521E0069A488 /* FlatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13DFC26C1521E0069A488 /* FlatMap.swift */; };
+		87F13E0426C1523B0069A488 /* Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13E0326C1523B0069A488 /* Flatten.swift */; };
+		87F13E0526C1523B0069A488 /* Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13E0326C1523B0069A488 /* Flatten.swift */; };
+		87F13E0626C1523B0069A488 /* Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13E0326C1523B0069A488 /* Flatten.swift */; };
+		87F13E0B26C152B60069A488 /* DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13E0A26C152B60069A488 /* DistinctUntilChanged.swift */; };
+		87F13E0C26C152B60069A488 /* DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13E0A26C152B60069A488 /* DistinctUntilChanged.swift */; };
+		87F13E0D26C152B60069A488 /* DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F13E0A26C152B60069A488 /* DistinctUntilChanged.swift */; };
 		CEA39D6025BEE05C00C452BC /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA39D5F25BEE05C00C452BC /* Timer.swift */; };
 		CEA39D6125BEE05C00C452BC /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA39D5F25BEE05C00C452BC /* Timer.swift */; };
 		CEA39D6225BEE05C00C452BC /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA39D5F25BEE05C00C452BC /* Timer.swift */; };
@@ -134,6 +176,20 @@
 		5FD28AD91D5B2E6300BAFC0F /* Fx tvOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Fx tvOS.h"; sourceTree = "<group>"; };
 		5FD28ADA1D5B2E6300BAFC0F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5FDB3D7F20EE6C4F0006CD8E /* FnFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FnFunctions.swift; sourceTree = "<group>"; };
+		87F13D8526C13D060069A488 /* Take.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Take.swift; sourceTree = "<group>"; };
+		87F13D8D26C13D180069A488 /* Map.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Map.swift; sourceTree = "<group>"; };
+		87F13D9826C13DB10069A488 /* AsVoid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsVoid.swift; sourceTree = "<group>"; };
+		87F13D9D26C13EBF0069A488 /* Observe+ExecutionContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observe+ExecutionContext.swift"; sourceTree = "<group>"; };
+		87F13DC526C14D320069A488 /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
+		87F13DD226C14D9D0069A488 /* Merge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Merge.swift; sourceTree = "<group>"; };
+		87F13DD926C14EF00069A488 /* CombineLatest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatest.swift; sourceTree = "<group>"; };
+		87F13DE026C14F370069A488 /* Zip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Zip.swift; sourceTree = "<group>"; };
+		87F13DE726C150530069A488 /* Throttled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throttled.swift; sourceTree = "<group>"; };
+		87F13DEE26C150940069A488 /* IgnoringNils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoringNils.swift; sourceTree = "<group>"; };
+		87F13DF526C1516B0069A488 /* CompactMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactMap.swift; sourceTree = "<group>"; };
+		87F13DFC26C1521E0069A488 /* FlatMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatMap.swift; sourceTree = "<group>"; };
+		87F13E0326C1523B0069A488 /* Flatten.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flatten.swift; sourceTree = "<group>"; };
+		87F13E0A26C152B60069A488 /* DistinctUntilChanged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistinctUntilChanged.swift; sourceTree = "<group>"; };
 		CEA39D5F25BEE05C00C452BC /* Timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timer.swift; sourceTree = "<group>"; };
 		CEA39D6625BEE09B00C452BC /* NotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -199,6 +255,7 @@
 		5F10E86B218C956B00B340C6 /* Reactive */ = {
 			isa = PBXGroup;
 			children = (
+				87F13D8426C13CE10069A488 /* Signal Operators */,
 				5F796E721D05C51800B8A7AC /* Disposable.swift */,
 				5F796E731D05C51800B8A7AC /* Signal.swift */,
 				5F9679A01ECDCE6E002EEADD /* SignalType.swift */,
@@ -310,6 +367,27 @@
 				5FD28ADA1D5B2E6300BAFC0F /* Info.plist */,
 			);
 			path = "Fx tvOS";
+			sourceTree = "<group>";
+		};
+		87F13D8426C13CE10069A488 /* Signal Operators */ = {
+			isa = PBXGroup;
+			children = (
+				87F13D8526C13D060069A488 /* Take.swift */,
+				87F13D8D26C13D180069A488 /* Map.swift */,
+				87F13D9826C13DB10069A488 /* AsVoid.swift */,
+				87F13D9D26C13EBF0069A488 /* Observe+ExecutionContext.swift */,
+				87F13DC526C14D320069A488 /* Filter.swift */,
+				87F13DD226C14D9D0069A488 /* Merge.swift */,
+				87F13DD926C14EF00069A488 /* CombineLatest.swift */,
+				87F13DE026C14F370069A488 /* Zip.swift */,
+				87F13DE726C150530069A488 /* Throttled.swift */,
+				87F13DEE26C150940069A488 /* IgnoringNils.swift */,
+				87F13DF526C1516B0069A488 /* CompactMap.swift */,
+				87F13DFC26C1521E0069A488 /* FlatMap.swift */,
+				87F13E0326C1523B0069A488 /* Flatten.swift */,
+				87F13E0A26C152B60069A488 /* DistinctUntilChanged.swift */,
+			);
+			path = "Signal Operators";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -468,7 +546,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				5FD28AAB1D5B27C100BAFC0F /* Property.swift in Sources */,
+				87F13D8E26C13D180069A488 /* Map.swift in Sources */,
 				5F10E8AE218CA0E800B340C6 /* Common.swift in Sources */,
+				87F13DDA26C14EF00069A488 /* CombineLatest.swift in Sources */,
 				5F10E870218C965F00B340C6 /* Closures.swift in Sources */,
 				5F9679951ECDBFCC002EEADD /* Result.swift in Sources */,
 				5FD28AA81D5B27C100BAFC0F /* Disposable.swift in Sources */,
@@ -477,15 +557,26 @@
 				CEA39D6725BEE09B00C452BC /* NotificationCenter.swift in Sources */,
 				5F17AFE1209216D900C6977A /* SignalPipe.swift in Sources */,
 				5FD28AA71D5B27C100BAFC0F /* Bag.swift in Sources */,
+				87F13DE826C150530069A488 /* Throttled.swift in Sources */,
 				5FD28AAC1D5B27C100BAFC0F /* Optional.swift in Sources */,
+				87F13D9926C13DB10069A488 /* AsVoid.swift in Sources */,
+				87F13DC626C14D320069A488 /* Filter.swift in Sources */,
 				5FD28AA11D5B27C100BAFC0F /* Operators.swift in Sources */,
+				87F13D8626C13D060069A488 /* Take.swift in Sources */,
 				5FA7E2951ECDDD8C00DEC12E /* ExecutionContext.swift in Sources */,
 				5FD28A9D1D5B27C100BAFC0F /* Functions.swift in Sources */,
 				5F10E874218C985200B340C6 /* Void.swift in Sources */,
 				5FDB3D8020EE6C4F0006CD8E /* FnFunctions.swift in Sources */,
+				87F13DD326C14D9D0069A488 /* Merge.swift in Sources */,
+				87F13D9E26C13EBF0069A488 /* Observe+ExecutionContext.swift in Sources */,
+				87F13DEF26C150940069A488 /* IgnoringNils.swift in Sources */,
+				87F13DE126C14F370069A488 /* Zip.swift in Sources */,
 				5FD28AA61D5B27C100BAFC0F /* Atomic.swift in Sources */,
 				5F9679A51ECDDA56002EEADD /* Promise.swift in Sources */,
+				87F13DF626C1516B0069A488 /* CompactMap.swift in Sources */,
+				87F13DFD26C1521E0069A488 /* FlatMap.swift in Sources */,
 				CEA39D6025BEE05C00C452BC /* Timer.swift in Sources */,
+				87F13E0426C1523B0069A488 /* Flatten.swift in Sources */,
 				5FB5C45B1D5C6D9400BA78A3 /* Weak.swift in Sources */,
 				5FC0E83425DE7FD400A41F45 /* Errors.swift in Sources */,
 				5FD28ACF1D5B27C800BAFC0F /* Bool.swift in Sources */,
@@ -495,6 +586,7 @@
 				5FD28AAA1D5B27C100BAFC0F /* Command.swift in Sources */,
 				5FD28AA21D5B27C100BAFC0F /* Application+Composition.swift in Sources */,
 				5FB881D922B946C000385DD6 /* Semigroup+Monoid.swift in Sources */,
+				87F13E0B26C152B60069A488 /* DistinctUntilChanged.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -505,22 +597,35 @@
 				5F10E87A218C9D5700B340C6 /* Optional.swift in Sources */,
 				5F10E88A218C9D5700B340C6 /* Weakify.swift in Sources */,
 				5F10E8AF218CAE2F00B340C6 /* Common.swift in Sources */,
+				87F13DDB26C14EF00069A488 /* CombineLatest.swift in Sources */,
 				5F10E88C218C9D5700B340C6 /* Result.swift in Sources */,
 				5F10E87B218C9D5700B340C6 /* Bool.swift in Sources */,
 				5F10E88D218C9D5700B340C6 /* Atomic.swift in Sources */,
 				5F10E87E218C9D5700B340C6 /* Promise.swift in Sources */,
 				CEA39D6825BEE09B00C452BC /* NotificationCenter.swift in Sources */,
+				87F13DB026C14CE10069A488 /* Take.swift in Sources */,
 				5F10E892218C9D5700B340C6 /* Closures.swift in Sources */,
 				5F10E87C218C9D5700B340C6 /* KVO.swift in Sources */,
+				87F13DE926C150530069A488 /* Throttled.swift in Sources */,
 				5F10E890218C9D5700B340C6 /* Weak.swift in Sources */,
+				87F13DB526C14CE30069A488 /* AsVoid.swift in Sources */,
+				87F13DCA26C14D340069A488 /* Filter.swift in Sources */,
 				5F10E87D218C9D5700B340C6 /* Void.swift in Sources */,
 				5F10E891218C9D5700B340C6 /* ExecutionContext.swift in Sources */,
 				5F10E881218C9D5700B340C6 /* Signal.swift in Sources */,
 				5F10E885218C9D5700B340C6 /* Property.swift in Sources */,
+				87F13DA826C14CDE0069A488 /* Map.swift in Sources */,
 				5F10E880218C9D5700B340C6 /* Disposable.swift in Sources */,
+				87F13DD426C14D9D0069A488 /* Merge.swift in Sources */,
+				87F13DBD26C14CE50069A488 /* Observe+ExecutionContext.swift in Sources */,
+				87F13DF026C150940069A488 /* IgnoringNils.swift in Sources */,
+				87F13DE226C14F370069A488 /* Zip.swift in Sources */,
 				5F10E888218C9D5700B340C6 /* Functions.swift in Sources */,
 				5F10E889218C9D5700B340C6 /* FnFunctions.swift in Sources */,
+				87F13DF726C1516B0069A488 /* CompactMap.swift in Sources */,
+				87F13DFE26C1521E0069A488 /* FlatMap.swift in Sources */,
 				CEA39D6125BEE05C00C452BC /* Timer.swift in Sources */,
+				87F13E0526C1523B0069A488 /* Flatten.swift in Sources */,
 				5F10E883218C9D5700B340C6 /* SignalPipe.swift in Sources */,
 				5FC0E83525DE7FD400A41F45 /* Errors.swift in Sources */,
 				5F10E887218C9D5700B340C6 /* Application+Composition.swift in Sources */,
@@ -530,6 +635,7 @@
 				5F10E884218C9D5700B340C6 /* Command.swift in Sources */,
 				5F10E882218C9D5700B340C6 /* SignalType.swift in Sources */,
 				5FB881DA22B946DE00385DD6 /* Semigroup+Monoid.swift in Sources */,
+				87F13E0C26C152B60069A488 /* DistinctUntilChanged.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -540,22 +646,35 @@
 				5F10E894218C9D5900B340C6 /* Optional.swift in Sources */,
 				5F10E8A4218C9D5900B340C6 /* Weakify.swift in Sources */,
 				5F10E8B0218CAE3000B340C6 /* Common.swift in Sources */,
+				87F13DDC26C14EF00069A488 /* CombineLatest.swift in Sources */,
 				5F10E8A6218C9D5900B340C6 /* Result.swift in Sources */,
 				5F10E895218C9D5900B340C6 /* Bool.swift in Sources */,
 				5F10E8A7218C9D5900B340C6 /* Atomic.swift in Sources */,
 				5F10E898218C9D5900B340C6 /* Promise.swift in Sources */,
 				CEA39D6925BEE09B00C452BC /* NotificationCenter.swift in Sources */,
+				87F13DB426C14CE10069A488 /* Take.swift in Sources */,
 				5F10E8AC218C9D5900B340C6 /* Closures.swift in Sources */,
 				5F10E896218C9D5900B340C6 /* KVO.swift in Sources */,
+				87F13DEA26C150530069A488 /* Throttled.swift in Sources */,
 				5F10E8AA218C9D5900B340C6 /* Weak.swift in Sources */,
+				87F13DB926C14CE30069A488 /* AsVoid.swift in Sources */,
+				87F13DCE26C14D350069A488 /* Filter.swift in Sources */,
 				5F10E897218C9D5900B340C6 /* Void.swift in Sources */,
 				5F10E8AB218C9D5900B340C6 /* ExecutionContext.swift in Sources */,
 				5F10E89B218C9D5900B340C6 /* Signal.swift in Sources */,
 				5F10E89F218C9D5900B340C6 /* Property.swift in Sources */,
+				87F13DAC26C14CDE0069A488 /* Map.swift in Sources */,
 				5F10E89A218C9D5900B340C6 /* Disposable.swift in Sources */,
+				87F13DD526C14D9D0069A488 /* Merge.swift in Sources */,
+				87F13DC126C14CE60069A488 /* Observe+ExecutionContext.swift in Sources */,
+				87F13DF126C150940069A488 /* IgnoringNils.swift in Sources */,
+				87F13DE326C14F370069A488 /* Zip.swift in Sources */,
 				5F10E8A2218C9D5900B340C6 /* Functions.swift in Sources */,
 				5F10E8A3218C9D5900B340C6 /* FnFunctions.swift in Sources */,
+				87F13DF826C1516B0069A488 /* CompactMap.swift in Sources */,
+				87F13DFF26C1521E0069A488 /* FlatMap.swift in Sources */,
 				CEA39D6225BEE05C00C452BC /* Timer.swift in Sources */,
+				87F13E0626C1523B0069A488 /* Flatten.swift in Sources */,
 				5F10E89D218C9D5900B340C6 /* SignalPipe.swift in Sources */,
 				5FC0E83625DE7FD400A41F45 /* Errors.swift in Sources */,
 				5F10E8A1218C9D5900B340C6 /* Application+Composition.swift in Sources */,
@@ -565,6 +684,7 @@
 				5F10E89E218C9D5900B340C6 /* Command.swift in Sources */,
 				5F10E89C218C9D5900B340C6 /* SignalType.swift in Sources */,
 				5FB881DB22B946DE00385DD6 /* Semigroup+Monoid.swift in Sources */,
+				87F13E0D26C152B60069A488 /* DistinctUntilChanged.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Reactive/Signal Operators/AsVoid.swift
+++ b/Source/Reactive/Signal Operators/AsVoid.swift
@@ -1,0 +1,3 @@
+public extension SignalType {
+	var asVoid: Signal<Void> { map { _ in () } }
+}

--- a/Source/Reactive/Signal Operators/CombineLatest.swift
+++ b/Source/Reactive/Signal Operators/CombineLatest.swift
@@ -1,0 +1,24 @@
+public extension SignalType {
+	func combineLatest<B>(_ signal: Signal<B>) -> Signal<(A, B)> {
+		Signal<(A, B)> { sink in
+			let disposable = CompositeDisposable()
+			var lastSelf: A? = nil
+			var lastOther: B? = nil
+
+			disposable += observe { value in
+				lastSelf = value
+				if let lastOther = lastOther {
+					sink((value, lastOther))
+				}
+			}
+			disposable += signal.observe { value in
+				lastOther = value
+				if let lastSelf = lastSelf {
+					sink((lastSelf, value))
+				}
+			}
+
+			return disposable
+		}
+	}
+}

--- a/Source/Reactive/Signal Operators/CompactMap.swift
+++ b/Source/Reactive/Signal Operators/CompactMap.swift
@@ -1,0 +1,8 @@
+public extension SignalType {
+	func compactMap<B>(_ f: @escaping (A) -> B?) -> Signal<B> {
+		self
+			.map(f)
+			.filter { $0 != nil }
+			.map { $0! }
+	}
+}

--- a/Source/Reactive/Signal Operators/CompactMap.swift
+++ b/Source/Reactive/Signal Operators/CompactMap.swift
@@ -1,8 +1,11 @@
 public extension SignalType {
 	func compactMap<B>(_ f: @escaping (A) -> B?) -> Signal<B> {
-		self
-			.map(f)
-			.filter { $0 != nil }
-			.map { $0! }
+		.init { sink in
+			observe {
+				guard let value = f($0) else { return }
+
+				sink(value)
+			}
+		}
 	}
 }

--- a/Source/Reactive/Signal Operators/DistinctUntilChanged.swift
+++ b/Source/Reactive/Signal Operators/DistinctUntilChanged.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public extension SignalType {
+	func distinctUntilChanged(_ comparator: @escaping (A, A) -> Bool) -> Signal<A> {
+		var lastValue: A?
+
+		return .init { sink in
+			observe { value in
+				defer { lastValue = value }
+				guard let lastValue = lastValue else {
+					return sink(value)
+				}
+
+				if comparator(lastValue, value) {
+					sink(value)
+				}
+			}
+		}
+	}
+}
+
+public extension SignalType where A: Equatable {
+	func distinctUntilChanged() -> Signal<A> {
+		distinctUntilChanged { $0 == $1 }
+	}
+}

--- a/Source/Reactive/Signal Operators/DistinctUntilChanged.swift
+++ b/Source/Reactive/Signal Operators/DistinctUntilChanged.swift
@@ -6,13 +6,9 @@ public extension SignalType {
 
 		return .init { sink in
 			observe { value in
-				defer { lastValue = value }
-				guard let lastValue = lastValue else {
+				if lastValue == nil || comparator(lastValue!, value) {
+					lastValue = value
 					return sink(value)
-				}
-
-				if comparator(lastValue, value) {
-					sink(value)
 				}
 			}
 		}

--- a/Source/Reactive/Signal Operators/Filter.swift
+++ b/Source/Reactive/Signal Operators/Filter.swift
@@ -1,0 +1,9 @@
+public extension SignalType {
+	func filter(_ f: @escaping (A) -> Bool) -> Signal<A> {
+		.init { sink in
+			observe {
+				f($0) ? sink($0) : ()
+			}
+		}
+	}
+}

--- a/Source/Reactive/Signal Operators/FlatMap.swift
+++ b/Source/Reactive/Signal Operators/FlatMap.swift
@@ -1,0 +1,5 @@
+public extension SignalType {
+	func flatMap<B>(_ f: @escaping (A) -> Signal<B>) -> Signal<B> {
+		map(f).flatten()
+	}
+}

--- a/Source/Reactive/Signal Operators/Flatten.swift
+++ b/Source/Reactive/Signal Operators/Flatten.swift
@@ -1,0 +1,11 @@
+public extension SignalType where A: SignalType {
+	func flatten() -> Signal<A.A> {
+		Signal { sink in
+			let disposable = CompositeDisposable()
+			disposable += observe { value in
+				disposable += value.observe(sink)
+			}
+			return disposable
+		}
+	}
+}

--- a/Source/Reactive/Signal Operators/IgnoringNils.swift
+++ b/Source/Reactive/Signal Operators/IgnoringNils.swift
@@ -1,0 +1,12 @@
+public extension SignalType where A: OptionalType {
+	@available(*, deprecated, message: "use `compactMap { $0 }` instead")
+	func ignoringNils() -> Signal<A.A> {
+		Signal { sink in
+			observe { value in
+				if let value = value.optional {
+					sink(value)
+				}
+			}
+		}
+	}
+}

--- a/Source/Reactive/Signal Operators/Map.swift
+++ b/Source/Reactive/Signal Operators/Map.swift
@@ -1,0 +1,7 @@
+public extension SignalType {
+	func map<B>(_ f: @escaping (A) -> B) -> Signal<B> {
+		Signal<B> {
+			observe($0 • f)
+		}
+	}
+}

--- a/Source/Reactive/Signal Operators/Merge.swift
+++ b/Source/Reactive/Signal Operators/Merge.swift
@@ -1,0 +1,10 @@
+public extension SignalType {
+	func merge(_ signal: Signal<A>) -> Signal<A> {
+		.init {
+			CompositeDisposable([
+				observe($0),
+				signal.observe($0)
+			])
+		}
+	}
+}

--- a/Source/Reactive/Signal Operators/Observe+ExecutionContext.swift
+++ b/Source/Reactive/Signal Operators/Observe+ExecutionContext.swift
@@ -1,0 +1,5 @@
+public extension SignalType {
+	func observe(_ ctx: ExecutionContext, _ f: @escaping (A) -> Void) -> Disposable {
+		observe { x in ctx.run { f(x) } }
+	}
+}

--- a/Source/Reactive/Signal Operators/Take.swift
+++ b/Source/Reactive/Signal Operators/Take.swift
@@ -1,0 +1,19 @@
+public extension SignalType {
+
+	func take(_ count: Int) -> Signal<A> {
+		let taken = Atomic(0)
+		return count <= 0 ? .empty : Signal { sink in
+			let disposable = SerialDisposable()
+			disposable.innerDisposable = observe { [weak disposable] x in
+				taken.modify {
+					guard $0 < count else { return }
+					sink(x)
+					$0 += 1
+					if $0 == count { disposable?.innerDisposable = nil }
+				}
+			}
+			return disposable
+		}
+	}
+}
+

--- a/Source/Reactive/Signal Operators/Throttled.swift
+++ b/Source/Reactive/Signal Operators/Throttled.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public extension SignalType {
+	func throttled(_ timeInterval: TimeInterval) -> Signal<A> {
+		.init {
+			observe(Fn.throttle(timeInterval, function: $0))
+		}
+	}
+
+	/// Throttled function with predicate to throttle
+	/// If `timeInterval` == 0 then signal will be notified immediately
+	func throttled(_ timeInterval: TimeInterval, shouldThrottle: @escaping (A) -> Bool) -> Signal<A> {
+		Signal { sink in
+			let disposable = SerialDisposable()
+			return observe { x in
+				if timeInterval > 0 && shouldThrottle(x) {
+					disposable.innerDisposable = Timer.once(timeInterval, { sink(x) })
+				} else {
+					disposable.dispose()
+					sink(x)
+				}
+			}
+		}
+	}
+}

--- a/Source/Reactive/Signal Operators/Zip.swift
+++ b/Source/Reactive/Signal Operators/Zip.swift
@@ -1,0 +1,28 @@
+public extension SignalType {
+	func zip<B>(_ signal: Signal<B>) -> Signal<(A, B)> {
+		Signal<(A, B)> { sink in
+			let disposable = CompositeDisposable()
+			var selfValues: [A] = []
+			var otherValues: [B] = []
+
+			let sendIfNeeded = {
+				if selfValues.count > 0 && otherValues.count > 0 {
+					let selfValue = selfValues.removeFirst()
+					let otherValue = otherValues.removeFirst()
+					sink((selfValue, otherValue))
+				}
+			}
+
+			disposable += observe { value in
+				selfValues.append(value)
+				sendIfNeeded()
+			}
+			disposable += signal.observe { value in
+				otherValues.append(value)
+				sendIfNeeded()
+			}
+
+			return disposable
+		}
+	}
+}

--- a/Source/Reactive/Signal.swift
+++ b/Source/Reactive/Signal.swift
@@ -10,12 +10,10 @@ public final class Signal<A>: SignalType {
 		let sendLock = NSLock()
 		sendLock.name = "com.github.P0ed.Fx"
 
-		let sink: (A) -> Void = { [weak self] value in
-			guard let welf = self else { return }
-
+		let sink: (A) -> Void = weakify(self) {
 			sendLock.lock()
-			for sink in welf.atomicSinks.value {
-				sink(value)
+			for sink in $0.atomicSinks.value {
+				sink($1)
 			}
 			sendLock.unlock()
 		}
@@ -45,145 +43,6 @@ public final class Signal<A>: SignalType {
 			return nil
 		}
 		return (signal: signal, put: put)
-	}
-}
-
-public extension Signal {
-
-	var asVoid: Signal<Void> { map { _ in () } }
-
-	func observe(_ ctx: ExecutionContext, _ f: @escaping (A) -> Void) -> Disposable {
-		observe { x in ctx.run { f(x) } }
-	}
-
-	func map<B>(_ f: @escaping (A) -> B) -> Signal<B> {
-		Signal<B> { sink in
-			observe(sink • f)
-		}
-	}
-
-	func filter(_ f: @escaping (A) -> Bool) -> Signal {
-		Signal<A> { sink in
-			observe { value in
-				if f(value) {
-					sink(value)
-				}
-			}
-		}
-	}
-
-	func merge(_ signal: Signal<A>) -> Signal<A> {
-		Signal<A> { sink in
-			let disposable = CompositeDisposable()
-			disposable += observe(sink)
-			disposable += signal.observe(sink)
-			return disposable
-		}
-	}
-
-	func combineLatest<B>(_ signal: Signal<B>) -> Signal<(A, B)> {
-		Signal<(A, B)> { sink in
-			let disposable = CompositeDisposable()
-			var lastSelf: A? = nil
-			var lastOther: B? = nil
-
-			disposable += observe { value in
-				lastSelf = value
-				if let lastOther = lastOther {
-					sink((value, lastOther))
-				}
-			}
-			disposable += signal.observe { value in
-				lastOther = value
-				if let lastSelf = lastSelf {
-					sink((lastSelf, value))
-				}
-			}
-
-			return disposable
-		}
-	}
-
-	func zip<B>(_ signal: Signal<B>) -> Signal<(A, B)> {
-		Signal<(A, B)> { sink in
-			let disposable = CompositeDisposable()
-			var selfValues: [A] = []
-			var otherValues: [B] = []
-
-			let sendIfNeeded = {
-				if selfValues.count > 0 && otherValues.count > 0 {
-					let selfValue = selfValues.removeFirst()
-					let otherValue = otherValues.removeFirst()
-					sink((selfValue, otherValue))
-				}
-			}
-
-			disposable += observe { value in
-				selfValues.append(value)
-				sendIfNeeded()
-			}
-			disposable += signal.observe { value in
-				otherValues.append(value)
-				sendIfNeeded()
-			}
-
-			return disposable
-		}
-	}
-
-	func throttled(_ timeInterval: TimeInterval) -> Signal {
-		Signal { sink in
-			observe(Fn.throttle(timeInterval, function: sink))
-		}
-	}
-
-	/// Throttled function with predicate to throttle
-	/// If `timeInterval` == 0 then signal will be notified immediately
-	func throttled(_ timeInterval: TimeInterval, shouldThrottle: @escaping (A) -> Bool) -> Signal {
-		Signal { sink in
-			let disposable = SerialDisposable()
-			return observe { x in
-				if timeInterval > 0 && shouldThrottle(x) {
-					disposable.innerDisposable = Timer.once(timeInterval, { sink(x) })
-				} else {
-					disposable.dispose()
-					sink(x)
-				}
-			}
-		}
-	}
-}
-
-public extension SignalType where A: OptionalType {
-
-	func ignoringNils() -> Signal<A.A> {
-		Signal { sink in
-			observe { value in
-				if let value = value.optional {
-					sink(value)
-				}
-			}
-		}
-	}
-}
-
-public extension SignalType where A: SignalType {
-
-	func flatten() -> Signal<A.A> {
-		Signal { sink in
-			let disposable = CompositeDisposable()
-			disposable += observe { value in
-				disposable += value.observe(sink)
-			}
-			return disposable
-		}
-	}
-}
-
-public extension Signal {
-
-	func flatMap<B>(_ f: @escaping (A) -> Signal<B>) -> Signal<B> {
-		map(f).flatten()
 	}
 }
 

--- a/Source/Reactive/SignalType.swift
+++ b/Source/Reactive/SignalType.swift
@@ -3,37 +3,3 @@ public protocol SignalType {
 
 	func observe(_ f: @escaping (A) -> Void) -> Disposable
 }
-
-public extension SignalType where A: Equatable {
-
-	func distinctUntilChanged() -> Signal<A> {
-		Signal<A> { sink in
-			var lastValue: A? = nil
-			return observe { value in
-				if lastValue == nil || lastValue! != value {
-					lastValue = value
-					sink(value)
-				}
-			}
-		}
-	}
-}
-
-public extension SignalType {
-
-	func take(_ count: Int) -> Signal<A> {
-		let taken = Atomic(0)
-		return count <= 0 ? .empty : Signal { sink in
-			let disposable = SerialDisposable()
-			disposable.innerDisposable = observe { [weak disposable] x in
-				taken.modify {
-					guard $0 < count else { return }
-					sink(x)
-					$0 += 1
-					if $0 == count { disposable?.innerDisposable = nil }
-				}
-			}
-			return disposable
-		}
-	}
-}


### PR DESCRIPTION
### Summary
* Moved all operators to single files for better navigation. They are located in `Source/Reactive/Signal Operators`
* Added new `distinctUntilChanged` operator, which optionally accepts custom comparator function
* Added new `compactMap` operator, which will transform mapped elements and discards optionals
* Deprecated `ignoringNils` in favor of `compactMap`
