### PR TITLE
Fix fn application operator

### DIFF
--- a/Sources/Fx/Operators/Operators.swift
+++ b/Sources/Fx/Operators/Operators.swift
@@ -1,5 +1,5 @@
-precedencegroup FxApplicativePrecedenceRight {
-	associativity: right
+precedencegroup FxApplicativePrecedence {
+	associativity: left
 	higherThan: AssignmentPrecedence
 	lowerThan: TernaryPrecedence
 }
@@ -11,7 +11,7 @@ precedencegroup FxCompositionPrecedence {
 
 
 /// Function application
-infix operator § : FxApplicativePrecedenceRight
+infix operator § : FxApplicativePrecedence
 
 /// Function composition
 infix operator • : FxCompositionPrecedence

--- a/Tests/FxTests/FxFunctions.swift
+++ b/Tests/FxTests/FxFunctions.swift
@@ -1,0 +1,19 @@
+import Fx
+import FxTestKit
+import XCTest
+
+final class FunctionsTests: XCTestCase {
+
+	func testComposition() {
+		let f = { $0 * 3 }
+		let g = { $0 + 3 }
+		let x = f • g § 3
+		XCTAssertEqual(x, 18)
+	}
+
+	func testApplication() {
+		let mul = curry(*) as (Int) -> (Int) -> Int
+		let x = mul § 2 § 3
+		XCTAssertEqual(x, 6)
+	}
+}


### PR DESCRIPTION
It is currently not possible to call function twice without using parentheses, the following won't compile:
```swift
let mul = curry(*) as (Int) -> (Int) -> Int
let x = mul § 2 § 3
```

With the `associativity: left` everything works as intended.