### PR TITLE
Add compact function

### DIFF
--- a/Sources/Fx/Functions/Functions.swift
+++ b/Sources/Fx/Functions/Functions.swift
@@ -82,3 +82,8 @@ public func run(after time: TimeInterval, on queue: DispatchQueue, task: @escapi
 	queue.asyncAfter(deadline: .now() + time, execute: item)
 	return ActionDisposable(action: item.cancel)
 }
+
+/// Useful with application operator. Write `§ compact` instead of `.compactMap(id)`.
+public func compact<S, T>(_ sequence: S) -> [T] where S: Sequence, S.Element == T? {
+	sequence.compactMap(id)
+}


### PR DESCRIPTION
In SwiftUI code we must specify `id` function like this `].compactMap(Fx.id)`.
Swift don't allow to add compact computed property in Sequence extension for now. But we can add function and use it like this `].compact()`. Or declare a global function to use it with application operator. This is what this PR about.